### PR TITLE
Fixed volume mapping for epg output

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
       # Persist database and app settings across container restarts
       - config:/config
       # Persist XMLTV output across container restarts (optional, only if you use the XMLTV output feature)
-      - xmltv:/xmltv
+      - xmltv:/app/xmltv
       # Mount a directory containing your PFX certificate for HTTPS
       # e.g., place lineup.pfx in ./certs/
       - ./certs:/app/certs:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       # Persist database and app settings across container restarts
       - config:/config
       # Persist XMLTV output across container restarts (optional, only if you use the XMLTV output feature)
-      - xmltv:/xmltv
+      - xmltv:/app/xmltv
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - Lineup__ConfigPath=/config


### PR DESCRIPTION
## Pull Request

### Description

I ran the compose file and realized the epg file is actually put in /app/xmltv rather than the existing /xmltv. [this is my very first pull request, please excuse me if I fail to follow conventions]

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

### Checklist

- [ x ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] All new and existing tests pass (`dotnet test`)
- [ x ] The project builds without warnings (`dotnet build`)
- [ ] I have updated documentation as needed
